### PR TITLE
Statics proxy definition

### DIFF
--- a/ansible/server-state-playbooks/www/www.yml
+++ b/ansible/server-state-playbooks/www/www.yml
@@ -125,6 +125,8 @@
         server: https://www-legacy.openmicroscopy.org/community
       - location: /qa2
         server: https://www-legacy.openmicroscopy.org/qa2
+        location: /static
+        server: https://www-legacy.openmicroscopy.org
       - location: /Schemas
         server: https://www-legacy.openmicroscopy.org/Schemas
       - location: /XMLschemas


### PR DESCRIPTION
Created a 'static' redirect to proxy for the css and images required by QA2 and any other apps which rely on this content.